### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -61,7 +61,6 @@ except ImportError:
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SSD1305.git"
 
-# pylint: disable-msg=bad-whitespace
 # register definitions
 SET_CONTRAST = const(0x81)
 SET_ENTIRE_ON = const(0xA4)
@@ -84,7 +83,6 @@ SET_AREA_COLOR = const(0xD8)
 SET_PRECHARGE = const(0xD9)
 SET_VCOM_DESEL = const(0xDB)
 SET_CHARGE_PUMP = const(0x8D)
-# pylint: enable-msg=bad-whitespace
 
 
 class _SSD1305(framebuf.FrameBuffer):


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.