### PR TITLE
Add type hints

### DIFF
--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -41,6 +41,13 @@ try:
 except ImportError:
     import adafruit_framebuf as framebuf
 
+try:
+    from digitalio import DigitalInOut
+    from busio import I2C, SPI
+    from typing import Optional
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SSD1305.git"
 
@@ -72,7 +79,15 @@ class _SSD1305(framebuf.FrameBuffer):
     """Base class for SSD1305 display driver"""
 
     # pylint: disable-msg=too-many-arguments
-    def __init__(self, buffer, width, height, *, external_vcc, reset):
+    def __init__(
+        self,
+        buffer: memoryview,
+        width: int,
+        height: int,
+        *,
+        external_vcc: bool,
+        reset: Optional[DigitalInOut]
+    ):
         super().__init__(buffer, width, height)
         self.width = width
         self.height = height
@@ -80,7 +95,7 @@ class _SSD1305(framebuf.FrameBuffer):
         # reset may be None if not needed
         self.reset_pin = reset
         if self.reset_pin:
-            self.reset_pin.switch_to_output(value=0)
+            self.reset_pin.switch_to_output(value=False)
         self.pages = self.height // 8
         self._column_offset = 0
         if self.height == 32:
@@ -91,7 +106,7 @@ class _SSD1305(framebuf.FrameBuffer):
         self.poweron()
         self.init_display()
 
-    def init_display(self):
+    def init_display(self) -> None:
         """Base class to initialize display"""
         for cmd in (
             SET_DISP | 0x00,  # off
@@ -135,39 +150,39 @@ class _SSD1305(framebuf.FrameBuffer):
         self.fill(0)
         self.show()
 
-    def poweroff(self):
+    def poweroff(self) -> None:
         """Turn off the display (nothing visible)"""
         self.write_cmd(SET_DISP | 0x00)
 
-    def contrast(self, contrast):
+    def contrast(self, contrast: int) -> None:
         """Adjust the contrast"""
         self.write_cmd(SET_CONTRAST)
         self.write_cmd(contrast)
 
-    def invert(self, invert):
+    def invert(self, invert: bool) -> None:
         """Invert all pixels on the display"""
         self.write_cmd(SET_NORM_INV | (invert & 1))
 
-    def write_framebuf(self):
+    def write_framebuf(self) -> None:
         """Derived class must implement this"""
         raise NotImplementedError
 
-    def write_cmd(self, cmd):
+    def write_cmd(self, cmd: int) -> None:
         """Derived class must implement this"""
         raise NotImplementedError
 
-    def poweron(self):
+    def poweron(self) -> None:
         "Reset device and turn on the display."
         if self.reset_pin:
-            self.reset_pin.value = 1
+            self.reset_pin.value = True
             time.sleep(0.001)
-            self.reset_pin.value = 0
+            self.reset_pin.value = False
             time.sleep(0.010)
-            self.reset_pin.value = 1
+            self.reset_pin.value = True
             time.sleep(0.010)
         self.write_cmd(SET_DISP | 0x01)
 
-    def show(self):
+    def show(self) -> None:
         """Update the display"""
         xpos0 = 0
         xpos1 = self.width - 1
@@ -197,7 +212,14 @@ class SSD1305_I2C(_SSD1305):
     """
 
     def __init__(
-        self, width, height, i2c, *, addr=0x3C, external_vcc=False, reset=None
+        self,
+        width: int,
+        height: int,
+        i2c: I2C,
+        *,
+        addr: int = 0x3C,
+        external_vcc: bool = False,
+        reset: Optional[DigitalInOut] = None
     ):
         self.i2c_device = i2c_device.I2CDevice(i2c, addr)
         self.addr = addr
@@ -217,14 +239,14 @@ class SSD1305_I2C(_SSD1305):
             reset=reset,
         )
 
-    def write_cmd(self, cmd):
+    def write_cmd(self, cmd: int) -> None:
         """Send a command to the SPI device"""
         self.temp[0] = 0x80  # Co=1, D/C#=0
         self.temp[1] = cmd
         with self.i2c_device:
             self.i2c_device.write(self.temp)
 
-    def write_framebuf(self):
+    def write_framebuf(self) -> None:
         """Blast out the frame buffer using a single I2C transaction to support
         hardware I2C interfaces."""
         with self.i2c_device:
@@ -248,20 +270,20 @@ class SSD1305_SPI(_SSD1305):
     # Disable should be reconsidered when refactor can be tested.
     def __init__(
         self,
-        width,
-        height,
-        spi,
-        dc,
-        reset,
-        cs,
+        width: int,
+        height: int,
+        spi: SPI,
+        dc: DigitalInOut,
+        reset: DigitalInOut,
+        cs: DigitalInOut,
         *,
-        external_vcc=False,
-        baudrate=8000000,
-        polarity=0,
-        phase=0
+        external_vcc: bool = False,
+        baudrate: int = 8000000,
+        polarity: int = 0,
+        phase: int = 0
     ):
         self.rate = 10 * 1024 * 1024
-        dc.switch_to_output(value=0)
+        dc.switch_to_output(value=False)
         self.spi_device = spi_device.SPIDevice(
             spi, cs, baudrate=baudrate, polarity=polarity, phase=phase
         )
@@ -275,14 +297,14 @@ class SSD1305_SPI(_SSD1305):
             reset=reset,
         )
 
-    def write_cmd(self, cmd):
+    def write_cmd(self, cmd: int) -> None:
         """Send a command to the SPI device"""
-        self.dc_pin.value = 0
+        self.dc_pin.value = False
         with self.spi_device as spi:
             spi.write(bytearray([cmd]))
 
-    def write_framebuf(self):
+    def write_framebuf(self) -> None:
         """write to the frame buffer via SPI"""
-        self.dc_pin.value = 1
+        self.dc_pin.value = True
         with self.spi_device as spi:
             spi.write(self.buffer)

--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -42,9 +42,9 @@ except ImportError:
     import adafruit_framebuf as framebuf
 
 try:
+    from typing import Optional
     from digitalio import DigitalInOut
     from busio import I2C, SPI
-    from typing import Optional
 except ImportError:
     pass
 

--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -42,6 +42,7 @@ except ImportError:
     import adafruit_framebuf as framebuf
 
 try:
+    # Used only for typing
     from typing import Optional
     from digitalio import DigitalInOut
     from busio import I2C, SPI


### PR DESCRIPTION
Hiya! I've added type hints for this (fixes #13).

I don't have a ton of experience with mypy, but these changes do seem to clear the errors returned from `mypy adafruit_ssd1305.py --disallow-untyped-defs`!

Thanks!