### PR TITLE
optional column offset

### DIFF
--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -241,6 +241,7 @@ class SSD1305_I2C(_SSD1305):
             height,
             external_vcc=external_vcc,
             reset=reset,
+            col=col  # <-- Forwarded col parameter to base class
         )
 
     def write_cmd(self, cmd: int) -> None:
@@ -284,7 +285,8 @@ class SSD1305_SPI(_SSD1305):
         external_vcc: bool = False,
         baudrate: int = 8000000,
         polarity: int = 0,
-        phase: int = 0
+        phase: int = 0,
+        col=None
     ):
         self.rate = 10 * 1024 * 1024
         dc.switch_to_output(value=False)
@@ -299,6 +301,7 @@ class SSD1305_SPI(_SSD1305):
             height,
             external_vcc=external_vcc,
             reset=reset,
+            col=col
         )
 
     def write_cmd(self, cmd: int) -> None:

--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -223,7 +223,7 @@ class SSD1305_I2C(_SSD1305):
         addr: int = 0x3C,
         external_vcc: bool = False,
         reset: Optional[DigitalInOut] = None,
-        col = None
+        col=None
     ):
         self.i2c_device = i2c_device.I2CDevice(i2c, addr)
         self.addr = addr

--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -87,7 +87,8 @@ class _SSD1305(framebuf.FrameBuffer):
         height: int,
         *,
         external_vcc: bool,
-        reset: Optional[DigitalInOut]
+        reset: Optional[DigitalInOut],
+        col: Optional[int] = None  # Shortened argument name
     ):
         super().__init__(buffer, width, height)
         self.width = width
@@ -98,9 +99,10 @@ class _SSD1305(framebuf.FrameBuffer):
         if self.reset_pin:
             self.reset_pin.switch_to_output(value=False)
         self.pages = self.height // 8
-        self._column_offset = 0
-        if self.height == 32:
-            self._column_offset = 4  # hardcoded for now...
+
+        # Set default column offset, allow override
+        self._column_offset = col if col is not None else 4
+
         # Note the subclass must initialize self.framebuf to a framebuffer.
         # This is necessary because the underlying data buffer is different
         # between I2C and SPI implementations (I2C needs an extra byte).
@@ -220,7 +222,8 @@ class SSD1305_I2C(_SSD1305):
         *,
         addr: int = 0x3C,
         external_vcc: bool = False,
-        reset: Optional[DigitalInOut] = None
+        reset: Optional[DigitalInOut] = None,
+        col = None
     ):
         self.i2c_device = i2c_device.I2CDevice(i2c, addr)
         self.addr = addr

--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -241,7 +241,7 @@ class SSD1305_I2C(_SSD1305):
             height,
             external_vcc=external_vcc,
             reset=reset,
-            col=col  # <-- Forwarded col parameter to base class
+            col=col, # <-- Forwarded col parameter to base class
         )
 
     def write_cmd(self, cmd: int) -> None:
@@ -301,7 +301,7 @@ class SSD1305_SPI(_SSD1305):
             height,
             external_vcc=external_vcc,
             reset=reset,
-            col=col
+            col=col,
         )
 
     def write_cmd(self, cmd: int) -> None:

--- a/adafruit_ssd1305.py
+++ b/adafruit_ssd1305.py
@@ -241,7 +241,7 @@ class SSD1305_I2C(_SSD1305):
             height,
             external_vcc=external_vcc,
             reset=reset,
-            col=col, # <-- Forwarded col parameter to base class
+            col=col,  # <-- Forwarded col parameter to base class
         )
 
     def write_cmd(self, cmd: int) -> None:


### PR DESCRIPTION
column offset had been hard coded to 4.

An updated [ADA# 2675 128x32 2.3" Monochrome OLED](https://www.adafruit.com/product/2675) needs an offset of col=0 to work.

Col=4 will remain default, but this override is being added for this one model which has changed behavior. 

[forum issue](https://forums.adafruit.com/viewtopic.php?t=217075)

Test on:

Pi4, Bookworm Lite, 64-bit with ADA# 2675

new constructor example:

```
oled = adafruit_ssd1305.SSD1305_I2C(WIDTH, HEIGHT, i2c, addr=0x3c, reset=oled_reset, col=0)
```



